### PR TITLE
fix: Client-side is not compatible with SockJS, SockJS removed

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,3 @@
 # Default ignored files
 /shelf/
-/Server_WizardSE2/.idea/workspace.xml
+.idea/workspace.xml

--- a/src/main/java/Websocket/Broker/WebsocketBrokerConfig.java
+++ b/src/main/java/Websocket/Broker/WebsocketBrokerConfig.java
@@ -19,7 +19,6 @@ public class WebsocketBrokerConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-broker")
-                .setAllowedOrigins("*")
-                .withSockJS();
+                .setAllowedOrigins("*");
     }
 }

--- a/src/test/java/Websocket/Broker/WebsocketBrokerConfigTest.java
+++ b/src/test/java/Websocket/Broker/WebsocketBrokerConfigTest.java
@@ -33,6 +33,5 @@ public class WebsocketBrokerConfigTest {
 
         verify(registry).addEndpoint("/ws-broker");
         verify(registration).setAllowedOrigins("*");
-        verify(registration).withSockJS();
     }
 }


### PR DESCRIPTION
Added a fix to registerStompEndpoints in WebsocketBrokerConfig.java, as the client side is not compatible with SockJS.